### PR TITLE
Remove redundant class_eval.

### DIFF
--- a/lib/with_rescue_from.rb
+++ b/lib/with_rescue_from.rb
@@ -8,21 +8,19 @@ module WithRescueFrom
 
   class_methods do
     def with_rescue_from(*method_names)
-      proxy = Module.new do |mod|
-        mod.class_eval do
-          method_names.each do |method_name|
-            define_method(method_name) do |*args, &block|
-              super(*args, &block)
-            rescue => e
-              rescue_with_handler(e) || raise
-            end
-  
-            ruby2_keywords method_name
+      proxy = Module.new do
+        method_names.each do |method_name|
+          define_method(method_name) do |*args, &block|
+            super(*args, &block)
+          rescue => e
+            rescue_with_handler(e) || raise
           end
+
+          ruby2_keywords method_name
         end
       end
 
-      self.prepend proxy
+      prepend proxy
     end
   end
 end


### PR DESCRIPTION
Remove redundant class_eval as the anonymous module is being prepended - so any defined methods will already be instance methods.